### PR TITLE
move to xenial and PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ cache:
 
 matrix:
   include:
-    - php: 8.0
-      env: WP_VERSION=latest
-    - php: 7.4
+    - php: 7.3
       env: WP_VERSION=latest
     - php: 8.0
       env: WP_TRAVISCI=phpcs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-dist: trusty
-
 language: php
 
 notifications:
@@ -13,9 +11,11 @@ cache:
 
 matrix:
   include:
-    - php: 7.4
+    - php: 8.0
       env: WP_VERSION=latest
     - php: 7.4
+      env: WP_VERSION=latest
+    - php: 8.0
       env: WP_TRAVISCI=phpcs
 
 before_script:


### PR DESCRIPTION
Trusty is EOL by Canonical and PHP 8.0 is Current Stable